### PR TITLE
Add support for binding callback function pipelines

### DIFF
--- a/addons/gd_data_binding/scripts/base_binding_source.gd
+++ b/addons/gd_data_binding/scripts/base_binding_source.gd
@@ -55,7 +55,8 @@ func bind_to(
 	target_object,
 	target_property: StringName,
 	converter_pipeline: BindingConverterPipeline = null,
-	target_value_change_signal = null
+	target_value_change_signal = null,
+	with_pipeline: BindingWithPipeline = null,
 ):
 	var binding_dict = _target_dict.get_or_add(source_property, {}) as Dictionary
 	var binding_key = _get_binding_key(target_object, target_property)
@@ -74,7 +75,8 @@ func bind_to(
 		target_object,
 		target_property,
 		converter_pipeline,
-		_get_signal(target_object, target_value_change_signal)
+		_get_signal(target_object, target_value_change_signal),
+		with_pipeline
 	)
 	binding_dict[binding_key] = binding
 
@@ -173,9 +175,10 @@ class BindingWithTargetSignal:
 		target_object,
 		target_property: StringName,
 		converter_pipeline: BindingConverterPipeline,
-		target_value_change_signal
+		target_value_change_signal,
+		with_pipeline: BindingWithPipeline = null,
 	):
-		super(source_object, source_property, target_object, target_property, converter_pipeline)
+		super(source_object, source_property, target_object, target_property, converter_pipeline, with_pipeline)
 
 		var source_value = source_object[source_property]
 		pass_source_value(source_value)

--- a/addons/gd_data_binding/scripts/binding.gd
+++ b/addons/gd_data_binding/scripts/binding.gd
@@ -13,6 +13,7 @@ var _target_property: StringName
 var _target_validator: Callable
 
 var _converter_pipeline: BindingConverterPipeline
+var _with_pipeline: BindingWithPipeline
 
 
 func _init(
@@ -20,7 +21,8 @@ func _init(
 	source_property: StringName,
 	target_object,
 	target_property: StringName,
-	converter_pipeline: BindingConverterPipeline = null
+	converter_pipeline: BindingConverterPipeline = null,
+	with_pipeline: BindingWithPipeline = null,
 ):
 	assert(
 		source_object is Object or source_object is Dictionary,
@@ -54,7 +56,8 @@ func _init(
 		_converter_pipeline = BindingConverterPipeline.new()
 	else:
 		_converter_pipeline = converter_pipeline
-
+		
+	_with_pipeline = with_pipeline
 
 func pass_source_value(source_value: Variant):
 	var prev_target_value = _target_object[_target_property]
@@ -72,6 +75,11 @@ func pass_target_value(target_value: Variant):
 		return
 
 	_source_object[_source_property] = next_source_value
+	
+	for with_func in _with_pipeline.get_pipeline():
+		assert(with_func.is_valid(), "The with function must be a valid Callable.")
+		with_func.call(_source_property, next_source_value)
+			
 
 
 static func _get_validator(object) -> Callable:

--- a/addons/gd_data_binding/scripts/binding_source.gd
+++ b/addons/gd_data_binding/scripts/binding_source.gd
@@ -32,11 +32,13 @@ class Binder:
 	var _source: BindingSource
 	var _source_property: StringName
 	var _converter_pipeline: BindingConverterPipeline
+	var _with_pipeline: BindingWithPipeline
 
 	func _init(
 		source: BindingSource,
 		source_property: StringName,
-		converter_pipeline: BindingConverterPipeline = null
+		converter_pipeline: BindingConverterPipeline = null,
+		with_pipeline: BindingWithPipeline = null
 	):
 		_source = source
 		_source_property = source_property
@@ -45,11 +47,22 @@ class Binder:
 			_converter_pipeline = BindingConverterPipeline.new()
 		else:
 			_converter_pipeline = converter_pipeline
+			
+		if with_pipeline == null:
+			_with_pipeline = BindingWithPipeline.new()
+		else:
+			_with_pipeline = with_pipeline
+			
 
 	func using(converter) -> Binder:
 		var converter_pipeline = _converter_pipeline.copy()
 		converter_pipeline.append(converter)
 		return Binder.new(_source, _source_property, converter_pipeline)
+		
+	func with(with_func: Callable):
+		var with_pipeline = _with_pipeline.copy()
+		with_pipeline.append(with_func)
+		return Binder.new(_source, _source_property, _converter_pipeline, with_pipeline)
 
 	func to(target_object, target_property: StringName, target_value_change_signal = null):
 		_source.bind_to(
@@ -57,7 +70,8 @@ class Binder:
 			target_object,
 			target_property,
 			_converter_pipeline,
-			target_value_change_signal
+			target_value_change_signal,
+			_with_pipeline
 		)
 
 	func to_toggle_button(toggle_button: BaseButton):
@@ -87,7 +101,7 @@ class Binder:
 
 	func to_color_rect(color_rect: ColorRect):
 		assert(_convert_to(TYPE_COLOR), "A value bound to ColorRect must be a color.")
-		to(color_rect, &"color")
+		to(color_rect, &"color", null)
 
 	func to_color_picker(color_picker: ColorPicker):
 		assert(_convert_to(TYPE_COLOR), "A value bound to ColorPicker must be a color.")
@@ -103,7 +117,7 @@ class Binder:
 
 	func to_label(label: Label):
 		assert(_convert_to(TYPE_STRING), "A value bound to Label must be a string.")
-		to(label, &"text")
+		to(label, &"text", null)
 
 	func to_line_edit(
 		line_edit: LineEdit, trigger: LineEditTrigger = LineEditTrigger.ON_FOCUS_EXITED

--- a/addons/gd_data_binding/scripts/binding_with_pipeline.gd
+++ b/addons/gd_data_binding/scripts/binding_with_pipeline.gd
@@ -1,0 +1,15 @@
+class_name BindingWithPipeline
+
+var _with_pipe: Array[Callable] = []
+
+func _init(with_pipe: Array[Callable] = []) -> void:
+	_with_pipe = with_pipe
+
+func append(with_func: Callable):
+	_with_pipe.append(with_func)
+
+func copy():
+	return BindingWithPipeline.new(_with_pipe.duplicate())
+	
+func get_pipeline() ->  Array[Callable]:
+	return _with_pipe


### PR DESCRIPTION
Here's a prototype implementation of callback function binding, which allows for functions to be triggered after data updates. Users can bind multiple custom callback functions using the `with` statement. This functionality is particularly useful for data storage, as users can save data via callback functions once it has been updated. Below is an example of its usage:

```gdscript
var _data = BindingSource.new(Data.new())
var _config_file = ConfigFile.new()

func _ready():
	_data.bind(&"count").using(_get_label).with(_on_data_changed).with(_on_data_changed_print)

func _on_button_pressed():
	_data.count += 1

func _on_data_changed(name, value):
	_config_file.set_value("section_name", name, value)
	_config_file.save("user://settings.cfg")

func _on_data_changed_print(name, value):
	prints(name, value)

class Data:
	var count: int = 0
```